### PR TITLE
ci: Change runner from macOS to Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,22 +8,17 @@ on:
 
 jobs:
   build:
-
-    runs-on: macos-13
-
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Select Xcode
-      run: sudo xcode-select -s /Applications/Xcode_14.3.1.app
+    - uses: swiftwasm/setup-swiftwasm@v1
+      with:
+        swift-version: "wasm-DEVELOPMENT-SNAPSHOT-2023-08-07-a"
     - name: Install tools
-      run: brew install wabt binaryen
-    - name: Install Wasm Toolchain
       run: |
-        VERSION=swift-wasm-DEVELOPMENT-SNAPSHOT-2023-08-07-a
-        TOOLCHAIN_URL="https://github.com/swiftwasm/swift/releases/download/$VERSION/$VERSION-macos_x86_64.pkg"
-        curl -LO $TOOLCHAIN_URL
-        installer -target CurrentUserHomeDirectory -pkg $VERSION-macos_x86_64.pkg
-        echo "PATH=$HOME/Library/Developer/Toolchains/$VERSION.xctoolchain/usr/bin:${PATH}" >> $GITHUB_ENV
+        sudo apt-get update
+        sudo apt-get install wabt binaryen
+    - run: swift --version
     - name: Build
       run: |
         swift build --product swift-format --triple wasm32-unknown-wasi -c release -Xlinker -z -Xlinker stack-size=524288


### PR DESCRIPTION
I changed the CI runner from macOS to Linux because Linux runners are basically cheaper than macOS runners.